### PR TITLE
Fix #7 Web書き込みされるファームウェアのサーボモータの設定をDynamixelに変更

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -47,6 +47,7 @@
     "config": {
         "sntp": "pool.ntp.org",
         "driver": {
+            "type": "dynamixel",
             "panId": 1,
             "tiltId": 2,
             "pwmPan": 5,

--- a/firmware/stackchan/manifest_local.json
+++ b/firmware/stackchan/manifest_local.json
@@ -7,9 +7,6 @@
             "type": "voicevox",
             "host": "192.168.7.136",
             "port": 50021
-        },
-        "driver": {
-            "type": "dynamixel"
         }
     }
 }


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
Web書き込みされるファームウェアのサーボモータの設定をDynamixelに変更します。
開発時のｽﾀｯｸﾁｬﾝのDriverの設定は `manifest_local.json` が反映されますが、Web書き込み用の `bundle`コマンドでは `manifest_local.json`は使いません。その結果 `scservo`を使う設定になっていました。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

https://github.com/rt-net/stack-chan/issues/7 をクローズします。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

以下の手順で確認しました。

* bundleでバイナリを生成

```
cd stack-chan/firmware
npm run bundle
mv stackchan/tech.moddable.stackchan ../web/flash/
```

* Web書き込み用ページをローカルホストに立ち上げ

```
cd stack-chan/firmware/web
npm run dev
```

* `localhost:8080`にアクセスし、[所定の手順](https://rt-net.jp/humanoid/archives/5907)でファームウェアを書き込み
* デフォルトファームウェアがｽﾀｯｸﾁｬﾝキットで動作することを確認

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
